### PR TITLE
setting(telegram): 텔레그램 알림 추가

### DIFF
--- a/.github/workflows/pr-created.yml
+++ b/.github/workflows/pr-created.yml
@@ -1,0 +1,28 @@
+name: Pull Request Created
+
+on:
+  pull_request:
+    types: [ready_for_review, review_requested]
+    branches-ignore:
+      - "main"
+
+jobs:
+  pull_request:
+    if: ${{ !github.event.pull_request.draft && github.event.requested_reviewer }}
+    name: Create PR alarm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send comment alarm message
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            새로운 PR이 생성되었습니다! 🎫
+
+            📰 PR 제목: ${{ github.event.pull_request.title }}
+            👤 PR 작성자: ${{ github.event.pull_request.user.login }}
+            🫂 리뷰어: ${{ github.event.requested_reviewer.login }}
+
+            다음 [링크](${{ github.event.pull_request.html_url }})를 확인해주세요!

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,66 @@
+name: Pull Request Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approved:
+    if: ${{ github.event.review.state == 'approved' }}
+    name: PR approved alarm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send comment alarm message
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            PR이 성공적으로 승인되었어요! ✅
+
+            📰 PR 제목: ${{ github.event.pull_request.title }}
+            👤 PR 작성자: ${{ github.event.pull_request.user.login }}
+            🗣️ 리뷰어: ${{ github.event.review.user.login }}
+
+            다음 [링크](${{ github.event.pull_request.html_url }})를 확인해주세요!
+
+  comment:
+    if: ${{ github.event.review.state == 'dismissed' }}
+    name: Comment alarm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send comment alarm message
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            PR 요청에 대한 답변이 달렸어요! 💬
+
+            📰 PR 제목: ${{ github.event.pull_request.title }}
+            👤 PR 작성자: ${{ github.event.pull_request.user.login }}
+            🗣️ 리뷰어: ${{ github.event.review.user.login }}
+
+            다음 [링크](${{ github.event.pull_request.html_url }})를 확인해주세요!
+
+  change_requested:
+    if: ${{ github.event.review.state == 'changes_requested' }}
+    name: Changed requested alarm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send comment alarm message
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            PR 수정 요청을 보냈습니다! 🖋️
+
+            📰 PR 제목: ${{ github.event.pull_request.title }}
+            👤 PR 작성자: ${{ github.event.pull_request.user.login }}
+            🗣️ 리뷰어: ${{ github.event.review.user.login }}
+
+            다음 [링크](${{ github.event.pull_request.html_url }})를 확인해주세요!


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

- PR 관련된 텔레그램 알림을 그룹채팅방의 텔레그램 봇이 전달하는 워크플로우를 추가했습니다.

## 📝 상세 설명

- PR이 생성되었을 때 PR 생성자, PR 리뷰어, PR URL 등이 작성된 알림을 전달합니다.
- PR에 대한 리뷰룰 작성했을 때, 리뷰 유형(`event.review.state`)에 따라 분기하여 알림을 전달합니다.

## ⚙️ 기타 사항

- PR 리뷰 전달을 위해 [`appleboy/telegram-action@master`](https://github.com/appleboy/telegram-action) 플러그인을 활용했습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
