### PR TITLE
fix(monster): 몬스터 수정 인풋 공백입력 방지 로직 추가

### DIFF
--- a/components/common/monster-image.tsx
+++ b/components/common/monster-image.tsx
@@ -154,6 +154,14 @@ export default function MonsterImage({
                   <FormControl>
                     <Input
                       {...field}
+                      onChange={(e) => {
+                        const space = /\s/
+                        if (space.test(e.target.value)) {
+                          return
+                        }
+
+                        field.onChange(e)
+                      }}
                       value={field.value || ""}
                       placeholder="전속성 공통이름 (ex. 드루이드)"
                     />
@@ -175,6 +183,11 @@ export default function MonsterImage({
                       placeholder="(ex. 물,물드루)"
                       onChange={(e) => {
                         const replaceValue = e.target.value.split(",")
+                        const space = /\s/
+
+                        if (space.test(e.target.value)) {
+                          return
+                        }
 
                         field.onChange(replaceValue)
                       }}

--- a/providers/query-provider.tsx
+++ b/providers/query-provider.tsx
@@ -9,7 +9,17 @@ import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experime
 export default function TanstackProviders({
   children,
 }: React.PropsWithChildren) {
-  const [client] = React.useState(new QueryClient())
+  const [client] = React.useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          refetchOnMount: false,
+          refetchOnWindowFocus: false,
+        },
+      },
+    })
+  )
 
   return (
     <QueryClientProvider client={client}>


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

- fix(monster): 몬스터 수정 인풋 공백입력 방지 로직 추가
- feat(setting): tanstack 기본설정 추가

## 📝 상세 설명

- 몬스터 데이터 1차 가공시 입력하는 인풋의 공백을 제한했습니다.
- tanstack 기본옵션을 추가했습니다.
  - retry: false,
  - refetch 관련: false 

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
