### PR TITLE
style(layout): 루트 레이아웃 세그먼트 별로 분리

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,17 @@
+import { SiteHeader } from "@/components/layout/site-header"
+
+interface AuthLayoutProps {
+  children: React.ReactNode
+}
+
+const AuthLayout = ({ children }: AuthLayoutProps) => {
+  return (
+    <div className="relative flex h-full flex-col">
+      <SiteHeader />
+
+      <main>{children}</main>
+    </div>
+  )
+}
+
+export default AuthLayout

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,11 +44,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         >
           <TanstackProviders>
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-              <div className="relative flex h-full flex-col">
-                <SiteHeader />
-
-                <main>{children}</main>
-              </div>
+              {children}
 
               {/* 디바이스 사이즈 체크 (화면 좌측하단) */}
               <TailwindIndicator />


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

루트 레이아웃 내 세그먼트 별로 분리되어야 할 레이아웃 요소들을 분리했습니다.

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- `<SiteHeader>` 컴포넌트를 `(auth)` 세그먼트 영역에서만 활용할 예정이기에, 해당 세그먼트 내 `layout.tsx`(`AuthLayout`)으로 이동하였습니다.
- 나머지 세그먼트(`(public)`)의 경우 경우에 따라 `sign-up` 과 나머지로 분리되어 레이아웃이 분기될 수 있으나 이 부분은 명확히 정해진 바가 없기 때문에 일단 `<SiteHeader>` 만 분리했습니다.

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 회원가입 UI 프로토타입의 경우 데브 스펙을 작성하여 공유하겠습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
