### PR TITLE
fix(monster): 몬스터 정보 저장 후 Popover가 닫히는 로직 추가

### DIFF
--- a/components/common/monster-image.tsx
+++ b/components/common/monster-image.tsx
@@ -1,11 +1,11 @@
-import { HTMLAttributes } from "react"
+import { HTMLAttributes, useState } from "react"
 
 import {
   MonsterInfo,
   monsterInfo as monsterInfoSchema,
 } from "@/interface/monster"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import axios from "axios"
 import clsx from "clsx"
 import { motion } from "framer-motion"
@@ -27,6 +27,8 @@ export default function MonsterImage({
   className,
   ...rest
 }: MonsterImageProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+
   const { toast } = useToast()
 
   const queryClient = useQueryClient()
@@ -41,6 +43,8 @@ export default function MonsterImage({
   const elementType = form.watch("elementType")
 
   const handleSubmit = async (monsterInfo: MonsterInfo) => {
+    setIsPopoverOpen(false)
+
     await axios
       .patch("/api/monster", monsterInfo)
       .then(() => queryClient.invalidateQueries({ queryKey: ["monster"] }))
@@ -49,7 +53,7 @@ export default function MonsterImage({
 
   return (
     <motion.div layout>
-      <Popover modal>
+      <Popover modal open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
         <PopoverTrigger asChild>
           <span
             className={clsx(


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> fix(monster): 몬스터 정보 저장 후 Popover가 닫히는 로직 추가

## 📝 상세 설명

> 몬스터정보 저장버튼 클릭시 Popover가 닫히도록 로직을 추가했습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
