### PR TITLE
style(page): page transition 추가

### DIFF
--- a/app/(auth)/feed/layout.tsx
+++ b/app/(auth)/feed/layout.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { ReactNode } from "react"
 
 import FeedAside from "@/components/feed/feed-aisde"

--- a/app/(auth)/feed/page.tsx
+++ b/app/(auth)/feed/page.tsx
@@ -1,6 +1,4 @@
-"use client"
-
-export default async function FeedPage() {
+export default function FeedPage() {
   return (
     <section className="container p-0">
       <div className="h-[500px]">1</div>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,17 +1,18 @@
+"use client"
+
+import PageContainer from "@/components/layout/page-container"
 import { SiteHeader } from "@/components/layout/site-header"
 
 interface AuthLayoutProps {
   children: React.ReactNode
 }
 
-const AuthLayout = ({ children }: AuthLayoutProps) => {
+export default function AuthLayout({ children }: AuthLayoutProps) {
   return (
-    <div className="relative flex h-full flex-col">
+    <PageContainer className="relative flex h-full flex-col">
       <SiteHeader />
 
       <main>{children}</main>
-    </div>
+    </PageContainer>
   )
 }
-
-export default AuthLayout

--- a/app/(public)/docs/page.tsx
+++ b/app/(public)/docs/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
+import PageContainer from "@/components/layout/page-container"
+
 export default function DocsPage() {
   return (
-    <div className="container flex h-full items-center justify-center gap-6 pb-8 pt-6 md:py-10">
+    <PageContainer className="container flex h-full items-center justify-center gap-6 pb-8 pt-6 md:py-10">
       <h2 className="relative text-center text-3xl font-extrabold leading-tight tracking-tighter md:text-4xl">
         Docs Page
       </h2>
-    </div>
+    </PageContainer>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/styles/monster.css"
 import { Metadata } from "next"
 
 import { TanstackProviders } from "@/providers/query-provider"
+import TransitionProvider from "@/providers/transition-provider"
 
 import { siteConfig } from "@/config/site"
 import { fontSans } from "@/lib/fonts"
@@ -44,7 +45,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         >
           <TanstackProviders>
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-              {children}
+              <TransitionProvider>{children}</TransitionProvider>
 
               {/* 디바이스 사이즈 체크 (화면 좌측하단) */}
               <TailwindIndicator />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,12 @@
 "use client"
 
-import { useRouter } from "next/navigation"
+import Link from "next/link"
 
-import { Button } from "@/components/ui/button"
+import PageContainer from "@/components/layout/page-container"
 
 export default function IndexPage() {
-  const { push: routerPush } = useRouter()
-
   return (
-    <section className="container flex h-[calc(100vh-65px)] items-center justify-center gap-6 pb-8 pt-6 md:py-10">
+    <PageContainer className="container flex h-[calc(100vh-65px)] items-center justify-center gap-6 pb-8 pt-6 md:py-10">
       <div className="flex max-w-[980px] flex-col items-center justify-center gap-2">
         <span
           className="inline-block h-[45px] w-[52px] bg-[position:-63px_-199px] bg-no-repeat"
@@ -19,10 +17,8 @@ export default function IndexPage() {
           Increase grow your Power
         </h2>
 
-        <Button variant="link" onClick={() => routerPush("/feed")}>
-          Go Main
-        </Button>
+        <Link href="/feed">Go Main</Link>
       </div>
-    </section>
+    </PageContainer>
   )
 }

--- a/components/feed/pusher-dialog.tsx
+++ b/components/feed/pusher-dialog.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { zodResolver } from "@hookform/resolvers/zod"
 import axios from "axios"
 import Pusher from "pusher"

--- a/components/layout/page-container.tsx
+++ b/components/layout/page-container.tsx
@@ -1,0 +1,48 @@
+import { HTMLAttributes, ReactNode } from "react"
+import { usePathname } from "next/navigation"
+
+import { Variants, motion } from "framer-motion"
+
+interface PageContainerProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode
+  as?: string
+}
+
+const variants: Variants = {
+  in: {
+    opacity: 1,
+    scale: 1,
+    x: 0,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  out: {
+    opacity: 0,
+    scale: 1,
+    x: -40,
+    transition: {
+      duration: 0.3,
+    },
+  },
+}
+
+export default function PageContainer({
+  children,
+  className,
+}: PageContainerProps) {
+  const pathName = usePathname()
+
+  return (
+    <motion.div
+      key={pathName}
+      variants={variants}
+      animate="in"
+      initial="out"
+      exit="out"
+      className={className}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/providers/transition-provider.tsx
+++ b/providers/transition-provider.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { ReactNode } from "react"
+import { usePathname } from "next/navigation"
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
+
+interface TransitionProviderProps {
+  children: ReactNode
+}
+
+export default function TransitionProvider({
+  children,
+}: TransitionProviderProps) {
+  return (
+    <AnimatePresence initial={false} mode="wait">
+      {children}
+    </AnimatePresence>
+  )
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- style(page): page transition 추가

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- Framer를 이용해 페이지 전환시 애니메이션 효과를 추가했습니다.
- 페이지가 되는 엔트리 파일에는 `<PageContainer></PageContainer>`를 사용하면 됩니다.
  - 예외 케이스로 `layout`이 분리되어 다른 엘리먼트가 있는 경우 <sup>auth/layout</sup> 에는 해당 `layout` 영역에 감아주어야 합니다.

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 페이지가 전환될때 out이 실행되고 다시 in 효과가 진행되는 코드를 적용 했었는데 이미 페이지가 전환되고나서 out > in 순으로 애니메이션이 진행되어 in 효과만 사용했습니다.
  - AppDir 라우팅 방식에 영향이 있는지 pages/_app.tsx 에서는 잘 작동하는 기능입니다. 

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
