### PR TITLE
fix(setting): prisma client 다중연결 오류수정

### DIFF
--- a/app/api/monster/route.ts
+++ b/app/api/monster/route.ts
@@ -2,9 +2,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { MonsterInfo } from "@/interface/monster"
-import { PrismaClient } from "@prisma/client"
 
-const prisma = new PrismaClient()
+import prisma from "@/lib/prisma"
 
 export async function GET() {
   const monsterList = await prisma.monster.findMany()

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,9 +1,8 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
 import { NextRequest, NextResponse } from "next/server"
 
-import { PrismaClient } from "@prisma/client"
-
-const prisma = new PrismaClient()
+import prisma from "@/lib/prisma"
 
 export async function POST(request: NextRequest) {
   const payload = await request.json()

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@prisma/client"
+
+const prismaClientSingleton = () => {
+  return new PrismaClient()
+}
+
+type PrismaClientSingleton = ReturnType<typeof prismaClientSingleton>
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClientSingleton | undefined
+}
+
+const prisma = globalForPrisma.prisma ?? prismaClientSingleton()
+
+export default prisma
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- fix(setting): prisma client 다중연결 오류수정 [HOTFIX]
  - `This is the 10th instance of Prisma Client being started. Make sure this is intentional` 에러 발생 

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 로컬에서 파일 변경때마다 prisma client가 계속 연결되던 사항수정
  - 이미 prisma와 연결이 되어있다면 그 세션을 유지하는 코드로 수정했습니다.
  - [블로그](https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) 

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
