### PR TITLE
feat(feed): 피드 검색기능 추가

### DIFF
--- a/app/(auth)/feed/page.tsx
+++ b/app/(auth)/feed/page.tsx
@@ -1,9 +1,12 @@
 import FeedList from "../src/ui/list/feed-list"
+import FeedSearch from "../src/ui/search/feed-search"
 import CommentSheet from "../src/ui/sheet/comment-sheet"
 
 export default function FeedPage() {
   return (
     <section className="container h-full">
+      <FeedSearch />
+
       <FeedList />
 
       <CommentSheet />

--- a/app/(auth)/src/hooks/useCommentList.ts
+++ b/app/(auth)/src/hooks/useCommentList.ts
@@ -1,7 +1,7 @@
 import { useSearchParams } from "next/navigation"
 
 import { CommentList } from "@/interface/comment"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import axios from "axios"
 
 import { apiRoute } from "@/lib/api-route"
@@ -10,8 +10,6 @@ export default function useCommentList() {
   const searchParams = useSearchParams()
 
   const feedId = searchParams.get("feedId")
-
-  const queryClient = useQueryClient()
 
   const { data: commentList, isLoading: isCommentListLoading } = useQuery(
     [apiRoute.Comment, feedId],

--- a/app/(auth)/src/hooks/useFeedList.ts
+++ b/app/(auth)/src/hooks/useFeedList.ts
@@ -1,3 +1,5 @@
+import { useSearchParams } from "next/navigation"
+
 import { FeedList } from "@/interface/feed"
 import { useQuery } from "@tanstack/react-query"
 import axios from "axios"
@@ -5,10 +7,20 @@ import axios from "axios"
 import { apiRoute } from "@/lib/api-route"
 
 export default function useFeedList() {
+  const searchParams = useSearchParams()
+
+  const searchTerm = searchParams.get("searchTerm")
+
   const { data: feedList = [], isLoading: isFeedListLoading } = useQuery(
-    [apiRoute.Feed],
+    [apiRoute.Feed, searchTerm],
     async () => {
-      return await axios.get<FeedList[]>(apiRoute.Feed).then((res) => res.data)
+      const hasSearchTerm = Boolean(searchTerm)
+
+      const url = hasSearchTerm
+        ? `${apiRoute.Feed}?searchTerm=${searchTerm}`
+        : apiRoute.Feed
+
+      return await axios.get<FeedList[]>(url).then((res) => res.data)
     }
   )
 

--- a/app/(auth)/src/ui/dialog/comment-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/comment-dialog.tsx
@@ -144,6 +144,41 @@ export default function CommentDialog({ children }: CommentDialogProps) {
 
                   {attackMonsterField.length <= 2 && (
                     <MonsterSearchDialog
+                      selectedMonster={
+                        attackMonsterField.length ? (
+                          <div className="flex w-full flex-col gap-4">
+                            <Separator />
+
+                            <span className="select-none text-sm font-bold">
+                              선택한 몬스터
+                            </span>
+
+                            <div className="flex gap-4">
+                              {attackMonsterField.map((monsterInfo) => {
+                                const selectedMonsterIndex =
+                                  attackMonsterField.findIndex(
+                                    ({ originName: selectedOriginName }) =>
+                                      selectedOriginName ===
+                                      monsterInfo.originName
+                                  )
+
+                                return (
+                                  <MonsterImage
+                                    className="cursor-pointer"
+                                    key={monsterInfo.id}
+                                    monsterInfo={monsterInfo}
+                                    onClick={() =>
+                                      handleAttackMonsterRemove(
+                                        selectedMonsterIndex
+                                      )
+                                    }
+                                  />
+                                )
+                              })}
+                            </div>
+                          </div>
+                        ) : undefined
+                      }
                       renderSearchedMonster={(monsterList) => (
                         <div className="flex max-h-[300px] flex-wrap items-center gap-4 overflow-y-auto overflow-x-hidden">
                           {monsterList.map((monsterInfo) => (

--- a/app/(auth)/src/ui/dialog/feed-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/feed-dialog.tsx
@@ -77,8 +77,6 @@ export default function FeedDialog({ children }: FeedDialogProps) {
   const handleSubmit = (values: DefenseMonster) => {
     createFeed(values)
 
-    console.log(values)
-
     handleReset()
   }
 

--- a/app/(auth)/src/ui/dialog/feed-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/feed-dialog.tsx
@@ -135,6 +135,41 @@ export default function FeedDialog({ children }: FeedDialogProps) {
 
                   {defenseMonsterField.length <= 2 && (
                     <MonsterSearchDialog
+                      selectedMonster={
+                        defenseMonsterField.length ? (
+                          <div className="flex w-full flex-col gap-4">
+                            <Separator />
+
+                            <span className="select-none text-sm font-bold">
+                              선택한 몬스터
+                            </span>
+
+                            <div className="flex gap-4">
+                              {defenseMonsterField.map((monsterInfo) => {
+                                const selectedMonsterIndex =
+                                  defenseMonsterField.findIndex(
+                                    ({ originName: selectedOriginName }) =>
+                                      selectedOriginName ===
+                                      monsterInfo.originName
+                                  )
+
+                                return (
+                                  <MonsterImage
+                                    className="cursor-pointer"
+                                    key={monsterInfo.id}
+                                    monsterInfo={monsterInfo}
+                                    onClick={() =>
+                                      handleDefenseMonsterRemove(
+                                        selectedMonsterIndex
+                                      )
+                                    }
+                                  />
+                                )
+                              })}
+                            </div>
+                          </div>
+                        ) : undefined
+                      }
                       renderSearchedMonster={(monsterList) => (
                         <div className="flex max-h-[300px] flex-wrap items-center gap-4 overflow-y-auto overflow-x-hidden">
                           {monsterList.map((monsterInfo) => (

--- a/app/(auth)/src/ui/dialog/monster-search-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/monster-search-dialog.tsx
@@ -15,11 +15,13 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 interface MonsterDialogProps {
+  selectedMonster: ReactNode
   /** 검색한 몬스터 정보를 다양한 UI로 노출시키기 위해 render props 사용 */
   renderSearchedMonster?: (monsterInfo: MonsterInfo[]) => ReactNode
 }
 
 export default function MonsterSearchDialog({
+  selectedMonster,
   renderSearchedMonster,
 }: MonsterDialogProps) {
   const [searchTerm, setSearchTerm] = useState("")
@@ -87,9 +89,13 @@ export default function MonsterSearchDialog({
         </div>
 
         {isVisibleSearchedMonster ? (
-          <div className="flex max-h-[300px] flex-wrap items-center gap-4 overflow-y-auto overflow-x-hidden">
-            {renderSearchedMonster(searchedMonsterList)}
-          </div>
+          <>
+            <div className="flex max-h-[300px] flex-wrap items-center gap-4 overflow-y-auto overflow-x-hidden">
+              {renderSearchedMonster(searchedMonsterList)}
+            </div>
+
+            {selectedMonster}
+          </>
         ) : (
           <>
             {searchTerm && (

--- a/app/(auth)/src/ui/list/feed-list.tsx
+++ b/app/(auth)/src/ui/list/feed-list.tsx
@@ -72,7 +72,7 @@ export default function FeedList() {
   const isAdmin = session?.user.role === accountRole.Enum.ADMIN
 
   return (
-    <div className="h-full py-4">
+    <div className="pb-4">
       {isFeedListLoading ? (
         <Loading className="h-full w-full" />
       ) : (

--- a/app/(auth)/src/ui/search/feed-search.tsx
+++ b/app/(auth)/src/ui/search/feed-search.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+
+import { DefenseMonsterSearch, defenseMonsterSearch } from "@/interface/feed"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+
+import { pageRoute } from "@/lib/page-route"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import { Icons } from "@/components/common/icons"
+
+export default function FeedSearch() {
+  const searchParams = useSearchParams()
+
+  const searchTerm = searchParams.get("searchTerm")
+
+  const { push } = useRouter()
+
+  const { success: hasSearchTerm } = defenseMonsterSearch.safeParse({
+    searchTerm,
+  })
+
+  const form = useForm<DefenseMonsterSearch>({
+    resolver: zodResolver(defenseMonsterSearch),
+    defaultValues: {
+      searchTerm: "",
+    },
+  })
+
+  const handleSubmit = ({ searchTerm }: DefenseMonsterSearch) => {
+    const isValidSearchTerm = Boolean(searchTerm)
+
+    const url = isValidSearchTerm
+      ? `${pageRoute.Feed}?searchTerm=${searchTerm}`
+      : pageRoute.Feed
+
+    push(url)
+  }
+
+  const handleReset = () => {
+    form.reset()
+
+    push(pageRoute.Feed)
+  }
+
+  return (
+    <div className="my-4">
+      <Form {...form}>
+        <form
+          className="relative flex h-full max-h-full gap-2"
+          onSubmit={form.handleSubmit(handleSubmit)}
+        >
+          <FormField
+            name="searchTerm"
+            render={({ field }) => (
+              <FormItem className="min-w-[267px]">
+                <FormLabel>검색</FormLabel>
+
+                <FormDescription>
+                  검색할 몬스터명 또는 키워드를 입력해주세요.
+                </FormDescription>
+
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="ex) 물해적, 해극해"
+                    autoComplete="off"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <div className="flex gap-2 self-end">
+            {hasSearchTerm && (
+              <Button
+                className="flex-1"
+                variant="secondary"
+                type="reset"
+                onClick={handleReset}
+              >
+                <span className="sr-only">검색 초기화</span>
+
+                <Icons.reset size={16} />
+              </Button>
+            )}
+
+            <Button className="flex-1" variant="outline" type="submit">
+              <span className="sr-only">검색</span>
+
+              <Icons.search size={16} />
+            </Button>
+          </div>
+        </form>
+      </Form>
+
+      <Separator className="mt-4" />
+    </div>
+  )
+}

--- a/components/common/icons.tsx
+++ b/components/common/icons.tsx
@@ -12,6 +12,7 @@ import {
   Mail,
   Moon,
   Plus,
+  RotateCcw,
   Search,
   SunMedium,
   Swords,
@@ -44,6 +45,7 @@ const Icons = {
   award: Award,
   mail: Mail,
   batteryCharging: BatteryCharging,
+  reset: RotateCcw,
   prev: (props: LucideProps) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/interface/feed.ts
+++ b/interface/feed.ts
@@ -8,8 +8,20 @@ const defenseMonster = z.object({
   defencseMonsterList: monsterList,
 })
 
+const defenseMonsterSearch = z.object({
+  searchTerm: z.string().optional(),
+})
+
 type DefenseMonster = z.infer<typeof defenseMonster>
+
+type DefenseMonsterSearch = z.infer<typeof defenseMonsterSearch>
 
 type FeedList = { author: User; comments: Comment[] } & Feed
 
-export { defenseMonster, type DefenseMonster, type FeedList }
+export {
+  defenseMonster,
+  defenseMonsterSearch,
+  type DefenseMonster,
+  type DefenseMonsterSearch,
+  type FeedList,
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- 메인 피드 검색기능 추가

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 피드 내 방어덱 생성시 입력했던 키워드, 방어덱 몬스터 리스트 내부 키워드, 몬스터명을 검색하는 컴포넌트를 추가했습니다.
![image](https://github.com/cyclops-operation/switter/assets/85790271/c790f2bd-e4ef-47f3-a0e5-a85247819d11)


## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- Feed API에서 Prisma를 통해 JSON으로 주고 받는 값에 대해 필터링하는 조건을 작성하는데 오래 걸렸습니다
   [공식문서](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-object-key-value-inside-array) 의 내용을 참고해서 작성했는데 monsterList 쪽 조건문은 검색어가 완벽히 일치해야 데이터가 오는 로직이라서 
   추후에 더 좋은 방법을 찾아봐야 할 것 같습니다
```js
where: {
  OR: [
    {
      monsterList: {
        path: "$[*].keyword",
        array_contains: searchTerm,
      },
    },
    {
      monsterList: {
        path: "$[*].monsterName",
        array_contains: searchTerm,
      },
    },
    {
      keyword: {
        contains: searchTerm,
      },
    },
  ],
},
```

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
