### PR TITLE
fix(create): 피드, 코멘트 생성시 중복체크 및 에러핸들러 추가

### DIFF
--- a/app/(auth)/feed/page.tsx
+++ b/app/(auth)/feed/page.tsx
@@ -1,15 +1,64 @@
+"use client"
+
+import { MouseEvent } from "react"
+
+import { AxiosError } from "axios"
+import { ErrorBoundary } from "react-error-boundary"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
 import FeedList from "../src/ui/list/feed-list"
 import FeedSearch from "../src/ui/search/feed-search"
 import CommentSheet from "../src/ui/sheet/comment-sheet"
+
+function FallbackCompnent({
+  error,
+  resetErrorBoundary,
+}: {
+  error: AxiosError
+  resetErrorBoundary: () => void
+}) {
+  const handleErrorReset = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
+    resetErrorBoundary()
+  }
+
+  return (
+    <AlertDialog open={Boolean(error)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{error.response?.data as string}</AlertDialogTitle>
+
+          <AlertDialogDescription>다시 시도해주세요.</AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={handleErrorReset}>확인</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
 
 export default function FeedPage() {
   return (
     <section className="container h-full">
       <FeedSearch />
 
-      <FeedList />
+      <ErrorBoundary FallbackComponent={FallbackCompnent}>
+        <FeedList />
 
-      <CommentSheet />
+        <CommentSheet />
+      </ErrorBoundary>
     </section>
   )
 }

--- a/app/(auth)/src/ui/dialog/comment-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/comment-dialog.tsx
@@ -55,6 +55,7 @@ export default function CommentDialog({ children }: CommentDialogProps) {
           title: "공격덱을 추가했습니다.",
         })
       },
+      useErrorBoundary: true,
     }
   )
 

--- a/app/(auth)/src/ui/dialog/feed-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/feed-dialog.tsx
@@ -66,6 +66,7 @@ export default function FeedDialog({ children }: FeedDialogProps) {
           title: "방어덱을 추가했습니다.",
         })
       },
+      useErrorBoundary: true,
     }
   )
 

--- a/app/api/action.ts
+++ b/app/api/action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { apiErrorCode, apiErrorMessage } from "@/lib/error-message"
+
+/** api error reponse 생성 */
+function createApiErrorResponse(
+  errorType: keyof typeof apiErrorCode,
+  errorMessage?: string
+) {
+  return new Response(errorMessage || apiErrorMessage[errorType], {
+    status: apiErrorCode[errorType],
+  })
+}
+
+export { createApiErrorResponse }

--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -4,9 +4,9 @@ import { attackMonster } from "@/interface/comment"
 import { getServerSession } from "next-auth"
 import z from "zod"
 
-import { apiErrorMessage } from "@/lib/error-message"
 import prisma from "@/lib/prisma"
 
+import { createApiErrorResponse } from "../action"
 import { authOptions } from "../auth/[...nextauth]/route"
 
 export async function GET(request: NextRequest) {
@@ -42,10 +42,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(commentList)
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest")
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }
 
@@ -58,10 +58,9 @@ export async function POST(request: NextRequest) {
 
     const session = await getServerSession(authOptions)
 
-    if (!session)
-      return new Response(apiErrorMessage.UnAuthorized, { status: 401 })
-    if (!feedId)
-      return new Response(apiErrorMessage.BadRequest, { status: 400 })
+    if (!session) return createApiErrorResponse("UnAuthorized")
+
+    if (!feedId) return createApiErrorResponse("BadRequest")
 
     await prisma.comment.create({
       data: {
@@ -74,10 +73,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ status: "ok" })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest")
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }
 
@@ -87,8 +86,7 @@ export async function DELETE(request: NextRequest) {
 
     const commentId = searchParams.get("commentId")
 
-    if (!commentId)
-      return new Response(apiErrorMessage.BadRequest, { status: 400 })
+    if (!commentId) return createApiErrorResponse("BadRequest")
 
     await prisma.comment.delete({
       where: {
@@ -99,9 +97,9 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ status: "ok" })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest", error.message)
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -14,6 +14,7 @@ type PatchMePayload = Partial<Omit<User, "id">>
 
 async function PATCH(request: NextRequest) {
   const payload: PatchMePayload = await request.json()
+
   const account = await getServerAccount()
 
   if (!account) throw new Error("로그인 된 유저가 없습니다.")

--- a/app/api/monster/route.ts
+++ b/app/api/monster/route.ts
@@ -4,8 +4,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { monsterInfo } from "@/interface/monster"
 import z from "zod"
 
-import { apiErrorMessage } from "@/lib/error-message"
 import prisma from "@/lib/prisma"
+
+import { createApiErrorResponse } from "../action"
 
 export async function GET() {
   try {
@@ -16,10 +17,10 @@ export async function GET() {
     return NextResponse.json(monsterList)
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest", error.message)
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }
 
@@ -40,9 +41,9 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ status: "ok" })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest", error.message)
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }

--- a/app/api/notification/route.ts
+++ b/app/api/notification/route.ts
@@ -3,16 +3,16 @@ import { NextRequest, NextResponse } from "next/server"
 import { notificationSchema } from "@/interface/notification"
 import z from "zod"
 
-import { apiErrorMessage } from "@/lib/error-message"
 import { pusher, pusherChannel, pusherEvent } from "@/lib/pusher"
 import { getServerAccount } from "@/lib/utils"
+
+import { createApiErrorResponse } from "../action"
 
 async function POST(request: NextRequest) {
   try {
     const account = await getServerAccount()
 
-    if (!account)
-      return new Response(apiErrorMessage.UnAuthorized, { status: 401 })
+    if (!account) return createApiErrorResponse("UnAuthorized")
 
     const payload = await request.json()
 
@@ -23,10 +23,10 @@ async function POST(request: NextRequest) {
     return NextResponse.json({ status: "ok" })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest", error.message)
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }
 

--- a/app/api/sheet/route.ts
+++ b/app/api/sheet/route.ts
@@ -3,9 +3,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { requestRowForm } from "@/interface/sheet"
 import z from "zod"
 
-import { apiErrorMessage } from "@/lib/error-message"
 import { getServerAccount } from "@/lib/utils"
 
+import { createApiErrorResponse } from "../action"
 import { loadSpreadsheets } from "./action"
 
 async function POST(request: NextRequest) {
@@ -16,15 +16,13 @@ async function POST(request: NextRequest) {
 
     const sheets = await loadSpreadsheets()
 
-    if (!sheets)
-      return new Response(apiErrorMessage.ServerError, { status: 500 })
+    if (!sheets) return createApiErrorResponse("ServerError")
 
     const sheet = sheets?.sheetsById[0]
 
     const account = await getServerAccount()
 
-    if (!account?.user.id)
-      return new Response(apiErrorMessage.ServerError, { status: 500 })
+    if (!account?.user.id) return createApiErrorResponse("ServerError")
 
     await sheet.addRow({
       requesterId: account?.user.id,
@@ -37,10 +35,10 @@ async function POST(request: NextRequest) {
     return NextResponse.json({ status: "ok" })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return new Response(error.message, { status: 400 })
+      return createApiErrorResponse("BadRequest", error.message)
     }
 
-    return new Response(apiErrorMessage.ServerError, { status: 500 })
+    return createApiErrorResponse("ServerError")
   }
 }
 

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -3,9 +3,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { User } from "@/interface/user"
 import { hash } from "bcryptjs"
 
-import { apiErrorMessage } from "@/lib/error-message"
 import prisma from "@/lib/prisma"
 
+import { createApiErrorResponse } from "../action"
 import { getUsers } from "./action"
 
 async function GET() {
@@ -23,7 +23,7 @@ async function POST(request: NextRequest) {
   const token = await hash(password, 10)
 
   if (!password || !token) {
-    return new Response(apiErrorMessage.BadRequest, { status: 400 })
+    return createApiErrorResponse("BadRequest")
   }
 
   await prisma.user.create({
@@ -42,7 +42,7 @@ async function PATCH(request: NextRequest) {
     await request.json()
 
   if (!id) {
-    return new Response(apiErrorMessage.BadRequest, { status: 400 })
+    return createApiErrorResponse("BadRequest")
   }
 
   await prisma.user.update({

--- a/lib/error-message.ts
+++ b/lib/error-message.ts
@@ -33,7 +33,7 @@ const formErrorMessage = {
 
 const apiErrorMessage = {
   BadRequest: "잘못된 요청입니다.",
-  Conflict: "잘못된 요청입니다.",
+  Conflict: "중복된 요청입니다.",
   UnAuthorized: "권한이 없습니다.",
   NotFound: "리소스를 찾을 수 없습니다.",
   ServerError: "서버요청에 에러가 발생했습니다.",

--- a/lib/error-message.ts
+++ b/lib/error-message.ts
@@ -33,9 +33,18 @@ const formErrorMessage = {
 
 const apiErrorMessage = {
   BadRequest: "잘못된 요청입니다.",
+  Conflict: "잘못된 요청입니다.",
   UnAuthorized: "권한이 없습니다.",
   NotFound: "리소스를 찾을 수 없습니다.",
   ServerError: "서버요청에 에러가 발생했습니다.",
+}
+
+const apiErrorCode = {
+  BadRequest: 400,
+  UnAuthorized: 401,
+  NotFound: 404,
+  ServerError: 500,
+  Conflict: 409,
 } as const
 
-export { apiErrorMessage, formErrorMessage }
+export { apiErrorCode, apiErrorMessage, formErrorMessage }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "pusher-js": "^8.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-hook-form": "^7.46.1",
     "sharp": "^0.31.3",
     "tailwind-merge": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,17 +165,17 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.16.tgz#180aead7f247305cce6551bea2720934e2fa2c95"
   integrity sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.21.0":
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
+  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.13.10", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.15.tgz#38f46494ccf6cf020bd4eed7124b425e83e523b8"
   integrity sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.21.0":
-  version "7.23.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
-  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -4647,6 +4647,13 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-hook-form@^7.46.1:
   version "7.46.1"


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- fix(create): 피드, 코멘트 생성시 중복체크 및 에러핸들러 추가
- fix(api): api 에러 server action 추가

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 피드, 코멘트 생성시 이미 등록된 몬스터 리스트와 동일하면 에러 모달을 노출시키도록 에러 바운더리를 추가했습니다.
- api 에러메시지를 생성하는 server action을 추가했습니다.

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 에러바운더리가 노출될때 Child로 노출되는 컴포넌트가 unmount 되면서 에러가 발생하는 것 같습니다. 치명적인 에러는 아닌 것 같아 원인 파악후에 수정하겠습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
