### PR TITLE
refactor(UX): 덱 추가 및 제거 로딩 설정 및 toast 추가

### DIFF
--- a/app/(auth)/admin/src/ui/role-select.tsx
+++ b/app/(auth)/admin/src/ui/role-select.tsx
@@ -39,7 +39,7 @@ export default function RoleSelect({ id, role }: RoleSelectProps) {
       }),
     {
       onSuccess: () => {
-        toast({ title: "유저 상태가 변경되었습니다." })
+        toast({ title: "유저 역할이 변경되었습니다." })
         refresh()
       },
     }

--- a/app/(auth)/src/hooks/useCommentDelete.ts
+++ b/app/(auth)/src/hooks/useCommentDelete.ts
@@ -4,31 +4,37 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import axios from "axios"
 
 import { apiRoute } from "@/lib/api-route"
+import { useToast } from "@/components/ui/use-toast"
 
 export default function useCommentDelete() {
   const searchParams = useSearchParams()
 
   const feedId = searchParams.get("feedId")
 
+  const { toast } = useToast()
+
   const queryClient = useQueryClient()
 
-  const { mutateAsync: deleteComment, isLoading: isDeleteCommentLoading } =
-    useMutation(
-      [apiRoute.Comment],
-      async (commentId: number) => {
-        if (!feedId) return
+  const { mutateAsync: deleteComment, isLoading } = useMutation(
+    [apiRoute.Comment],
+    async (commentId: number) => {
+      if (!feedId) return
 
-        await axios.delete(`${apiRoute.Comment}?commentId=${commentId}`)
+      await axios.delete(`${apiRoute.Comment}?commentId=${commentId}`)
+    },
+    {
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries([apiRoute.Comment, feedId]),
+          queryClient.invalidateQueries([apiRoute.Feed]),
+        ])
+
+        toast({
+          title: "공격덱이 삭제되었습니다.",
+        })
       },
-      {
-        onSuccess: async () => {
-          await Promise.all([
-            queryClient.invalidateQueries([apiRoute.Comment, feedId]),
-            queryClient.invalidateQueries([apiRoute.Feed]),
-          ])
-        },
-      }
-    )
+    }
+  )
 
-  return { deleteComment, isDeleteCommentLoading }
+  return { deleteComment, isLoading }
 }

--- a/app/(auth)/src/hooks/useFeedDelete.ts
+++ b/app/(auth)/src/hooks/useFeedDelete.ts
@@ -3,11 +3,14 @@ import axios from "axios"
 
 import { apiRoute } from "@/lib/api-route"
 import { getDynamicRoute } from "@/lib/utils"
+import { useToast } from "@/components/ui/use-toast"
 
 export default function useFeedDelete() {
   const queryClient = useQueryClient()
 
-  const { mutateAsync: deleteFeed } = useMutation(
+  const { toast } = useToast()
+
+  const { mutateAsync: deleteFeed, isLoading } = useMutation(
     [apiRoute.Feed],
     async (feedId: number) => {
       await axios.delete(
@@ -24,9 +27,13 @@ export default function useFeedDelete() {
           queryClient.invalidateQueries([apiRoute.Feed]),
           queryClient.invalidateQueries([apiRoute.Comment]),
         ])
+
+        toast({
+          title: "방어덱이 제거되었습니다.",
+        })
       },
     }
   )
 
-  return { deleteFeed }
+  return { deleteFeed, isLoading }
 }

--- a/app/(auth)/src/ui/dialog/comment-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/comment-dialog.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/ui/use-toast"
+import FullPageLoading from "@/components/common/loading/full-page"
 import MonsterImage from "@/components/common/monster-image"
 
 import MonsterSearchDialog from "./monster-search-dialog"
@@ -40,7 +41,7 @@ export default function CommentDialog({ children }: CommentDialogProps) {
 
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
-  const { mutate: createComment } = useMutation(
+  const { mutate: createComment, isLoading } = useMutation(
     [apiRoute.Feed],
     async (comment: AttackMonster) => {
       return axios.post(apiRoute.Comment, { ...comment, feedId })
@@ -85,6 +86,8 @@ export default function CommentDialog({ children }: CommentDialogProps) {
     createComment(values)
     handleReset()
   }
+
+  if (isLoading) return <FullPageLoading />
 
   return (
     <Dialog

--- a/app/(auth)/src/ui/dialog/feed-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/feed-dialog.tsx
@@ -23,6 +23,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/ui/use-toast"
+import FullPageLoading from "@/components/common/loading/full-page"
 import MonsterImage from "@/components/common/monster-image"
 
 import MonsterSearchDialog from "./monster-search-dialog"
@@ -55,7 +56,7 @@ export default function FeedDialog({ children }: FeedDialogProps) {
     name: "defencseMonsterList",
   })
 
-  const { mutate: createFeed } = useMutation(
+  const { mutate: createFeed, isLoading } = useMutation(
     [apiRoute.Feed],
     async (feed: DefenseMonster) => axios.post(apiRoute.Feed, feed),
     {
@@ -80,6 +81,8 @@ export default function FeedDialog({ children }: FeedDialogProps) {
 
     handleReset()
   }
+
+  if (isLoading) return <FullPageLoading />
 
   return (
     <Dialog

--- a/app/(auth)/src/ui/list/feed-list.tsx
+++ b/app/(auth)/src/ui/list/feed-list.tsx
@@ -33,6 +33,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/common/icons"
 import Loading from "@/components/common/loading"
+import FullPageLoading from "@/components/common/loading/full-page"
 import { Meteors } from "@/components/common/meteor-effect"
 import MonsterImage from "@/components/common/monster-image"
 
@@ -54,7 +55,7 @@ export default function FeedList() {
 
   const { feedList, isFeedListLoading } = useFeedList()
 
-  const { deleteFeed } = useFeedDelete()
+  const { deleteFeed, isLoading } = useFeedDelete()
 
   const handleFeedDelete = (feedId: number) => {
     if (!feedId) throw Error(apiErrorMessage.BadRequest)
@@ -75,6 +76,8 @@ export default function FeedList() {
   const userId = session?.user.id
 
   const isAdmin = session?.user.role === userRole.Enum.ADMIN
+
+  if (isLoading) return <FullPageLoading />
 
   return (
     <div className="h-full pb-4">

--- a/app/(auth)/src/ui/list/feed-list.tsx
+++ b/app/(auth)/src/ui/list/feed-list.tsx
@@ -33,7 +33,6 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/common/icons"
 import Loading from "@/components/common/loading"
-import FullPageLoading from "@/components/common/loading/full-page"
 import { Meteors } from "@/components/common/meteor-effect"
 import MonsterImage from "@/components/common/monster-image"
 
@@ -55,7 +54,7 @@ export default function FeedList() {
 
   const { feedList, isFeedListLoading } = useFeedList()
 
-  const { deleteFeed, isLoading } = useFeedDelete()
+  const { deleteFeed } = useFeedDelete()
 
   const handleFeedDelete = (feedId: number) => {
     if (!feedId) throw Error(apiErrorMessage.BadRequest)
@@ -76,8 +75,6 @@ export default function FeedList() {
   const userId = session?.user.id
 
   const isAdmin = session?.user.role === userRole.Enum.ADMIN
-
-  if (isLoading) return <FullPageLoading />
 
   return (
     <div className="h-full pb-4">

--- a/app/(auth)/src/ui/sheet/comment-sheet.tsx
+++ b/app/(auth)/src/ui/sheet/comment-sheet.tsx
@@ -61,7 +61,8 @@ export default function CommentSheet() {
 
   const { commentList, isCommentListLoading } = useCommentList()
 
-  const { deleteComment, isDeleteCommentLoading } = useCommentDelete()
+  const { deleteComment, isLoading: isDeleteCommentLoading } =
+    useCommentDelete()
 
   const isPresent = useIsPresent()
 


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

덱 추가 및 제거 분기에 로딩 화면을 보여주고 토스트를 추가합니다.

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 공격덱, 방어덱 추가 및 제거가 진행될 때 뮤테이션의 `isLoading` 활용하여 로딩 화면을 추가했습니다.
  - 이를 통해 뮤테이션 진행 동안은 별도의 인터랙션을 허용하지 않으려 하며, 가시적으로 요청이 진행되고 있음을 표현하고 싶었습니다.
- 각 요청이 성공할 경우 토스트를 띄웁니다.
  - 요청 결과를 토스트로 명확하게 전달될 수 있도록 하고 싶었습니다.

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 추상화와 관련된 사항은 별도의 PR로 진행할 예정입니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
