### PR TITLE
refactor: 피드 추상화 작업

### DIFF
--- a/app/(auth)/src/hooks/useCommentList.ts
+++ b/app/(auth)/src/hooks/useCommentList.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation"
 
-import { CommentList } from "@/interface/comment"
+import { CommentItem } from "@/interface/comment"
 import { useQuery } from "@tanstack/react-query"
 import axios from "axios"
 
@@ -15,7 +15,7 @@ export default function useCommentList() {
     [apiRoute.Comment, feedId],
     async () => {
       return await axios
-        .get<CommentList[]>(`${apiRoute.Comment}?feedId=${feedId}`)
+        .get<CommentItem[]>(`${apiRoute.Comment}?feedId=${feedId}`)
         .then((res) => res.data)
     },
     {

--- a/app/(auth)/src/hooks/useFeedDelete.ts
+++ b/app/(auth)/src/hooks/useFeedDelete.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation"
 
-import { FeedList } from "@/interface/feed"
+import { FeedItem } from "@/interface/feed"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import axios from "axios"
 
@@ -20,7 +20,7 @@ export default function useFeedDelete() {
   const { mutateAsync: deleteFeed, isLoading } = useMutation(
     [apiRoute.Feed],
     async (feedId: number) => {
-      queryClient.setQueryData<FeedList[]>(
+      queryClient.setQueryData<FeedItem[]>(
         [apiRoute.Feed, searchTerm],
         (list) => list?.filter(({ id }) => id !== feedId)
       )

--- a/app/(auth)/src/hooks/useFeedList.ts
+++ b/app/(auth)/src/hooks/useFeedList.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation"
 
-import { FeedList } from "@/interface/feed"
+import { FeedItem } from "@/interface/feed"
 import { useQuery } from "@tanstack/react-query"
 import axios from "axios"
 
@@ -21,7 +21,7 @@ export default function useFeedList() {
         },
       })
 
-      return await axios.get<FeedList[]>(url).then((res) => res.data)
+      return await axios.get<FeedItem[]>(url).then((res) => res.data)
     }
   )
 

--- a/app/(auth)/src/ui/card/comment-card.tsx
+++ b/app/(auth)/src/ui/card/comment-card.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { CommentItem } from "@/interface/comment"
+import { monsterList } from "@/interface/monster"
+import { userRole } from "@/interface/user"
+import clsx from "clsx"
+
+import { dateDistanceToNow } from "@/lib/date"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/common/icons"
+import MonsterImage from "@/components/common/monster-image"
+
+import DeleteDialog from "../dialog/delete-dialog"
+
+interface CommentCardProps extends CommentItem {
+  onDelete?: (id: number) => void
+}
+
+const CommentCard = ({
+  id,
+  author,
+  createdAt,
+  monsterList: attackMonsterList,
+  onDelete,
+}: CommentCardProps) => {
+  const commentList = monsterList.parse(attackMonsterList)
+
+  return (
+    <div className="group relative flex h-max cursor-pointer justify-between gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
+      <div className="flex flex-col items-center gap-2 backdrop-blur-sm">
+        <div className="flex flex-col gap-1">
+          <span className="flex select-none flex-col">
+            <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
+              {author.role === userRole.Enum.ADMIN ? (
+                <Icons.crown className="mr-0.5" size={14} />
+              ) : (
+                <Icons.award size={14} />
+              )}
+              {author.guildName}
+            </em>
+            <em className="text-sm font-semibold not-italic text-foreground">
+              {author.nickname}
+            </em>
+          </span>
+
+          <span className="flex select-none gap-1 text-xs font-medium text-gray-400">
+            {dateDistanceToNow(createdAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="relative z-50 flex h-4/6 items-center justify-center gap-2">
+        {commentList.map((monsterInfo) => {
+          return (
+            <MonsterImage
+              key={monsterInfo.id}
+              className="cursor-auto drop-shadow-lg"
+              monsterInfo={monsterInfo}
+            />
+          )
+        })}
+      </div>
+
+      {onDelete && (
+        <div
+          className={clsx(
+            "absolute inset-0 z-50 flex items-center justify-center opacity-0 transition-all bg-foreground/30",
+            {
+              "group-hover:opacity-100": true,
+            }
+          )}
+        >
+          <DeleteDialog
+            title="공격덱을 삭제하시겠습니까?"
+            description="삭제한 공격덱은 복구가 불가능합니다."
+            onDelete={() => {
+              onDelete(id)
+            }}
+          >
+            <Button
+              className="hover:bg-transparent"
+              variant="ghost"
+              size="menu"
+            >
+              <i className="global-menu remove" />
+            </Button>
+          </DeleteDialog>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CommentCard

--- a/app/(auth)/src/ui/card/feed-card.tsx
+++ b/app/(auth)/src/ui/card/feed-card.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { FeedItem } from "@/interface/feed"
+import { MonsterList } from "@/interface/monster"
+import { userRole } from "@/interface/user"
+import { Comment } from "@prisma/client"
+import clsx from "clsx"
+
+import { dateDistanceToNow } from "@/lib/date"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/common/icons"
+import { Meteors } from "@/components/common/meteor-effect"
+import MonsterImage from "@/components/common/monster-image"
+
+import DeleteDialog from "../dialog/delete-dialog"
+
+interface FeedCardProps extends FeedItem {
+  onDelete?: (id: number) => void
+}
+
+const FeedCard = ({
+  id,
+  author,
+  viewCount,
+  createdAt,
+  monsterList,
+  comments,
+  onDelete,
+}: FeedCardProps) => {
+  const defenseMonsterList = monsterList as MonsterList
+  const attackMonsterList = comments as Comment[]
+
+  return (
+    <div className="group relative flex h-max cursor-pointer flex-col gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
+      <div className="relative z-50 flex justify-between gap-2 backdrop-blur-sm">
+        <div className="flex gap-2">
+          <Avatar>
+            <AvatarImage src="https://github.com/shadcn.png" />
+            <AvatarFallback>{author.nickname}</AvatarFallback>
+          </Avatar>
+
+          <div className="flex flex-col gap-1">
+            <span className="flex select-none items-center gap-1">
+              <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
+                {author.role === userRole.Enum.ADMIN ? (
+                  <Icons.crown className="mr-0.5" size={14} />
+                ) : (
+                  <Icons.award size={14} />
+                )}
+
+                {author.guildName}
+              </em>
+
+              <em className="max-w-[120px] truncate text-sm font-semibold not-italic text-foreground">
+                {author.nickname}
+              </em>
+            </span>
+
+            <span className="ml-[2px] flex select-none gap-1 text-xs font-medium text-gray-400">
+              {dateDistanceToNow(createdAt)}
+            </span>
+          </div>
+        </div>
+
+        {onDelete && (
+          <DeleteDialog
+            title="방어덱을 삭제하시겠습니까?"
+            description="방어덱을 삭제하면 연관된 공격덱도 모두
+                삭제됩니다."
+            onDelete={() => onDelete(id)}
+          >
+            <Button className="self-start" variant="ghost" size="icon-sm">
+              <Icons.trash className="h-5 w-5 text-foreground opacity-70" />
+            </Button>
+          </DeleteDialog>
+        )}
+      </div>
+
+      <div className="relative z-50 flex h-4/6 items-center justify-center gap-2">
+        {defenseMonsterList.map((monsterInfo, index) => {
+          const firstIndex = index === 0
+          const lastIndex = index === defenseMonsterList.length - 1
+
+          return (
+            <div key={monsterInfo.id} className="flex h-full items-center">
+              <MonsterImage
+                className={clsx(
+                  "drop-shadow-lg transition-transform duration-300",
+                  {
+                    "group-hover:translate-y-1": firstIndex,
+                    "group-hover:translate-y-[-4px]": lastIndex,
+                  }
+                )}
+                monsterInfo={monsterInfo}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          <Icons.eye size={18} className="text-foreground opacity-70" />
+          <span className="select-none text-xs font-semibold">{viewCount}</span>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Icons.swords
+            size={16}
+            className={clsx("text-foreground opacity-70", {
+              "group-hover:animate-shake": attackMonsterList.length,
+            })}
+          />
+          <span className="select-none text-xs font-semibold">
+            {attackMonsterList?.length}
+          </span>
+        </div>
+      </div>
+
+      <Meteors
+        number={8}
+        className="invisible transition-all group-hover:visible group-hover:animate-meteor-effect"
+      />
+    </div>
+  )
+}
+
+export default FeedCard

--- a/app/(auth)/src/ui/dialog/delete-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/delete-dialog.tsx
@@ -1,0 +1,70 @@
+import { ReactElement } from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { buttonVariants } from "@/components/ui/button"
+
+interface DeleteDialogProps {
+  children: ReactElement
+  title: string
+  description: string
+  onDelete: () => void
+}
+
+const DeleteDialog = ({
+  children,
+  title,
+  description,
+  onDelete,
+}: DeleteDialogProps) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        asChild
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+      >
+        {children}
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="select-none">{title}</AlertDialogTitle>
+
+          <AlertDialogDescription className="select-none">
+            {description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
+            취소
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete()
+            }}
+            className={buttonVariants({
+              variant: "destructive",
+            })}
+          >
+            삭제
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default DeleteDialog

--- a/app/(auth)/src/ui/list/feed-list.tsx
+++ b/app/(auth)/src/ui/list/feed-list.tsx
@@ -2,10 +2,7 @@
 
 import { useRouter } from "next/navigation"
 
-import { MonsterList } from "@/interface/monster"
 import { userRole } from "@/interface/user"
-import { Comment } from "@prisma/client"
-import clsx from "clsx"
 import {
   AnimatePresence,
   AnimationProps,
@@ -14,30 +11,15 @@ import {
 } from "framer-motion"
 import { useSession } from "next-auth/react"
 
-import { dateDistanceToNow } from "@/lib/date"
 import { apiErrorMessage } from "@/lib/error-message"
 import { pageRoute } from "@/lib/page-route"
 import { getDynamicRoute } from "@/lib/utils"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Button, buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/common/icons"
 import Loading from "@/components/common/loading"
-import { Meteors } from "@/components/common/meteor-effect"
-import MonsterImage from "@/components/common/monster-image"
 
 import useFeedDelete from "../../hooks/useFeedDelete"
 import useFeedList from "../../hooks/useFeedList"
+import FeedCard from "../card/feed-card"
 import FeedDialog from "../dialog/feed-dialog"
 
 const animations: AnimationProps = {
@@ -72,7 +54,7 @@ export default function FeedList() {
 
   const isPresent = useIsPresent()
 
-  const userId = session?.user.id
+  const sessionUserId = session?.user.id
 
   const isAdmin = session?.user.role === userRole.Enum.ADMIN
 
@@ -92,172 +74,36 @@ export default function FeedList() {
           </FeedDialog>
 
           <AnimatePresence>
-            {feedList.map(
-              ({ monsterList, id, author, createdAt, comments, viewCount }) => {
-                const defenseMonsterList = monsterList as MonsterList
-                const attackMonsterList = comments as Comment[]
+            {feedList.map((props) => {
+              return (
+                <motion.li
+                  key={props.id}
+                  className="relative z-0"
+                  layout
+                  style={
+                    isPresent
+                      ? { position: "static" }
+                      : { position: "absolute" }
+                  }
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
 
-                return (
-                  <motion.li
-                    key={id}
-                    className="relative z-0"
-                    layout
-                    style={
-                      isPresent
-                        ? { position: "static" }
-                        : { position: "absolute" }
+                    handleFeedClick(props.id)
+                  }}
+                  {...animations}
+                >
+                  <FeedCard
+                    {...props}
+                    onDelete={
+                      isAdmin || sessionUserId === props.author.id
+                        ? (id) => handleFeedDelete(id)
+                        : undefined
                     }
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-
-                      handleFeedClick(id)
-                    }}
-                    {...animations}
-                  >
-                    <div className="group relative flex h-max cursor-pointer flex-col gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
-                      <div className="relative z-50 flex justify-between gap-2 backdrop-blur-sm">
-                        <div className="flex gap-2">
-                          <Avatar>
-                            <AvatarImage src="https://github.com/shadcn.png" />
-                            <AvatarFallback>{author.nickname}</AvatarFallback>
-                          </Avatar>
-
-                          <div className="flex flex-col gap-1">
-                            <span className="flex select-none items-center gap-1">
-                              <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
-                                {author.role === userRole.Enum.ADMIN ? (
-                                  <Icons.crown className="mr-0.5" size={14} />
-                                ) : (
-                                  <Icons.award size={14} />
-                                )}
-
-                                {author.guildName}
-                              </em>
-
-                              <em className="max-w-[120px] truncate text-sm font-semibold not-italic text-foreground">
-                                {author.nickname}
-                              </em>
-                            </span>
-
-                            <span className="ml-[2px] flex select-none gap-1 text-xs font-medium text-gray-400">
-                              {dateDistanceToNow(createdAt)}
-                            </span>
-                          </div>
-                        </div>
-
-                        {(isAdmin || userId === author.id) && (
-                          <AlertDialog>
-                            <AlertDialogTrigger
-                              asChild
-                              onClick={(e) => {
-                                e.stopPropagation()
-                              }}
-                            >
-                              <Button
-                                className="self-start"
-                                variant="ghost"
-                                size="icon-sm"
-                              >
-                                <Icons.trash className="h-5 w-5 text-foreground opacity-70" />
-                              </Button>
-                            </AlertDialogTrigger>
-
-                            <AlertDialogContent>
-                              <AlertDialogHeader>
-                                <AlertDialogTitle className="select-none">
-                                  방어덱을 삭제하시겠습니까?
-                                </AlertDialogTitle>
-
-                                <AlertDialogDescription className="select-none">
-                                  방어덱을 삭제하면 연관된 공격덱도 모두
-                                  삭제됩니다.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-
-                              <AlertDialogFooter>
-                                <AlertDialogCancel
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  취소
-                                </AlertDialogCancel>
-                                <AlertDialogAction
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    handleFeedDelete(id)
-                                  }}
-                                  className={buttonVariants({
-                                    variant: "destructive",
-                                  })}
-                                >
-                                  삭제
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        )}
-                      </div>
-
-                      <div className="relative z-50 flex h-4/6 items-center justify-center gap-2">
-                        {defenseMonsterList.map((monsterInfo, index) => {
-                          const firstIndex = index === 0
-                          const lastIndex =
-                            index === defenseMonsterList.length - 1
-
-                          return (
-                            <div
-                              key={monsterInfo.id}
-                              className="flex h-full items-center"
-                            >
-                              <MonsterImage
-                                className={clsx(
-                                  "drop-shadow-lg transition-transform duration-300",
-                                  {
-                                    "group-hover:translate-y-1": firstIndex,
-                                    "group-hover:translate-y-[-4px]": lastIndex,
-                                  }
-                                )}
-                                monsterInfo={monsterInfo}
-                              />
-                            </div>
-                          )
-                        })}
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-1">
-                          <Icons.eye
-                            size={18}
-                            className="text-foreground opacity-70"
-                          />
-                          <span className="select-none text-xs font-semibold">
-                            {viewCount}
-                          </span>
-                        </div>
-
-                        <div className="flex items-center gap-1">
-                          <Icons.swords
-                            size={16}
-                            className={clsx("text-foreground opacity-70", {
-                              "group-hover:animate-shake":
-                                attackMonsterList.length,
-                            })}
-                          />
-                          <span className="select-none text-xs font-semibold">
-                            {attackMonsterList?.length}
-                          </span>
-                        </div>
-                      </div>
-
-                      <Meteors
-                        number={8}
-                        className="invisible transition-all group-hover:visible group-hover:animate-meteor-effect"
-                      />
-                    </div>
-                  </motion.li>
-                )
-              }
-            )}
+                  />
+                </motion.li>
+              )
+            })}
           </AnimatePresence>
         </ul>
       )}

--- a/app/(auth)/src/ui/sheet/comment-sheet.tsx
+++ b/app/(auth)/src/ui/sheet/comment-sheet.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 
-import { MonsterList, monsterList } from "@/interface/monster"
+import { MonsterList } from "@/interface/monster"
 import { userRole } from "@/interface/user"
 import clsx from "clsx"
 import {
@@ -14,21 +14,8 @@ import {
 } from "framer-motion"
 import { useSession } from "next-auth/react"
 
-import { dateDistanceToNow } from "@/lib/date"
 import { apiErrorMessage } from "@/lib/error-message"
 import { pageRoute } from "@/lib/page-route"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
 import {
   Sheet,
   SheetContent,
@@ -41,6 +28,7 @@ import MonsterImage from "@/components/common/monster-image"
 
 import useCommentDelete from "../../hooks/useCommentDelete"
 import useCommentList from "../../hooks/useCommentList"
+import CommentCard from "../card/comment-card"
 import CommentDialog from "../dialog/comment-dialog"
 
 const animations: AnimationProps = {
@@ -68,7 +56,7 @@ export default function CommentSheet() {
 
   const isLoading = isCommentListLoading || isDeleteCommentLoading
 
-  const userId = session?.user.id
+  const sessionUserId = session?.user.id
 
   const isAdmin = session?.user.role === userRole.Enum.ADMIN
 
@@ -167,121 +155,29 @@ export default function CommentSheet() {
               {hasCommentList && (
                 <ul className="grid grid-cols-2 gap-4 max-lg:grid-cols-1">
                   <AnimatePresence>
-                    {commentList?.map(
-                      ({
-                        id,
-                        author,
-                        createdAt,
-                        monsterList: attackMonsterList,
-                      }) => {
-                        const commentList = monsterList.parse(attackMonsterList)
-
-                        return (
-                          <motion.li
-                            key={id}
-                            layout
-                            style={
-                              isPresent
-                                ? { position: "static" }
-                                : { position: "absolute" }
+                    {commentList?.map((props) => {
+                      return (
+                        <motion.li
+                          key={props.id}
+                          layout
+                          style={
+                            isPresent
+                              ? { position: "static" }
+                              : { position: "absolute" }
+                          }
+                          {...animations}
+                        >
+                          <CommentCard
+                            {...props}
+                            onDelete={
+                              isAdmin || sessionUserId === props.author.id
+                                ? (id) => handleCommentDelete(id)
+                                : undefined
                             }
-                            {...animations}
-                          >
-                            <div className="group relative flex h-max cursor-pointer justify-between gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
-                              <div className="flex flex-col items-center gap-2 backdrop-blur-sm">
-                                <div className="flex flex-col gap-1">
-                                  <span className="flex select-none flex-col">
-                                    <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
-                                      {author.role === userRole.Enum.ADMIN ? (
-                                        <Icons.crown
-                                          className="mr-0.5"
-                                          size={14}
-                                        />
-                                      ) : (
-                                        <Icons.award size={14} />
-                                      )}
-                                      {author.guildName}
-                                    </em>
-                                    <em className="text-sm font-semibold not-italic text-foreground">
-                                      {author.nickname}
-                                    </em>
-                                  </span>
-
-                                  <span className="flex select-none gap-1 text-xs font-medium text-gray-400">
-                                    {dateDistanceToNow(createdAt)}
-                                  </span>
-                                </div>
-                              </div>
-
-                              <div className="relative z-50 flex h-4/6 items-center justify-center gap-2">
-                                {commentList.map((monsterInfo) => {
-                                  return (
-                                    <MonsterImage
-                                      key={monsterInfo.id}
-                                      className="cursor-auto drop-shadow-lg"
-                                      monsterInfo={monsterInfo}
-                                    />
-                                  )
-                                })}
-                              </div>
-
-                              <div
-                                className={clsx(
-                                  "absolute inset-0 z-50 flex items-center justify-center opacity-0 transition-all bg-foreground/30",
-                                  {
-                                    "group-hover:opacity-100":
-                                      isAdmin || userId === author.id,
-                                  }
-                                )}
-                              >
-                                <AlertDialog>
-                                  <AlertDialogTrigger asChild>
-                                    <Button
-                                      className="hover:bg-transparent"
-                                      variant="ghost"
-                                      size="menu"
-                                    >
-                                      <i className="global-menu remove" />
-                                    </Button>
-                                  </AlertDialogTrigger>
-
-                                  <AlertDialogContent>
-                                    <AlertDialogHeader>
-                                      <AlertDialogTitle className="select-none">
-                                        공격덱을 삭제하시겠습니까?
-                                      </AlertDialogTitle>
-
-                                      <AlertDialogDescription className="select-none">
-                                        삭제한 공격덱은 복구가 불가능합니다.
-                                      </AlertDialogDescription>
-                                    </AlertDialogHeader>
-
-                                    <AlertDialogFooter>
-                                      <AlertDialogCancel>
-                                        취소
-                                      </AlertDialogCancel>
-                                      <AlertDialogAction
-                                        disabled={!feedId}
-                                        onClick={(e) => {
-                                          e.stopPropagation()
-
-                                          handleCommentDelete(id)
-                                        }}
-                                        className={buttonVariants({
-                                          variant: "destructive",
-                                        })}
-                                      >
-                                        삭제
-                                      </AlertDialogAction>
-                                    </AlertDialogFooter>
-                                  </AlertDialogContent>
-                                </AlertDialog>
-                              </div>
-                            </div>
-                          </motion.li>
-                        )
-                      }
-                    )}
+                          />
+                        </motion.li>
+                      )
+                    })}
                   </AnimatePresence>
                 </ul>
               )}

--- a/interface/comment.ts
+++ b/interface/comment.ts
@@ -10,6 +10,6 @@ const attackMonster = z.object({
 
 type AttackMonster = z.infer<typeof attackMonster>
 
-type CommentList = { author: User; id: number } & { feed: Feed } & Comment
+type CommentItem = { author: User; id: number } & { feed: Feed } & Comment
 
-export { attackMonster, type AttackMonster, type CommentList }
+export { attackMonster, type AttackMonster, type CommentItem }

--- a/interface/feed.ts
+++ b/interface/feed.ts
@@ -21,12 +21,12 @@ type DefenseMonster = z.infer<typeof defenseMonster>
 
 type DefenseMonsterSearch = z.infer<typeof defenseMonsterSearch>
 
-type FeedList = { author: User; comments: Comment[] } & Feed
+type FeedItem = { author: User; comments: Comment[] } & Feed
 
 export {
   defenseMonster,
   defenseMonsterSearch,
   type DefenseMonster,
   type DefenseMonsterSearch,
-  type FeedList,
+  type FeedItem,
 }


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

피드와 관련된 작업 내용 중 추상화가 필요한 영역에 대해서 간략한 추상화를 진행했습니다.

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 피드와 코멘트를 매핑하는 부분에서 각 카드의 추상화를 진행했습니다.
  - `FeedCard` 와 `CommentCard` 로 구분됩니다.
  - 각 컴포넌트는 옵셔널한 `onDelete` prop을 전달받아 조건부로 삭제가 가능합니다.
- 삭제를 진행할 때 사용하는 Dialog 컴포넌트를 공통화 했습니다.
  - `DeleteDialog` 이며 트리거에 해당하는 컴포넌트를 `children` 으로 전달 받습니다.
- zod로 정의돈 피드와 코멘트 타입의 접미사를 `~List` 에서 `~Item` 으로 변경했습니다.
  - 배열이 아닌 각 아이템에 해당하므로 `List` 보단 `Item` 이 낫다고 판단하였습니다.

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 명확히 추상화가 필요하다고 생각한 부분만을 진행했습니다. 추가적으로 추상화가 필요한 부분들은 추후 작업 진행해주시면 됩니다.
- 추가적으로 코멘트 삭제 시 권한에 따라 삭제가 가능한 부분에서 버그가 있어 이에 대한 부분도 동시에 수정했습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
