### PR TITLE
fix(comment): comment 내부 description 기능 추가

### DIFF
--- a/app/(auth)/admin/monster/src/ui/monster-table.tsx
+++ b/app/(auth)/admin/monster/src/ui/monster-table.tsx
@@ -3,13 +3,10 @@
 import { ChangeEvent, useEffect, useState } from "react"
 
 import useDebounceState from "@/hook/useDebounceState"
-import {
-  MonsterElement,
-  MonsterInfo,
-  monsterElement,
-} from "@/interface/monster"
+import { MonsterElement, MonsterInfo } from "@/interface/monster"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import axios from "axios"
+import clsx from "clsx"
 
 import { apiRoute } from "@/lib/api-route"
 import { getDynamicRoute } from "@/lib/utils"
@@ -33,18 +30,7 @@ import DeleteDialog from "@/app/(auth)/src/ui/dialog/delete-dialog"
 import MonsterManageDialog from "@/app/(auth)/src/ui/dialog/monster-manage-dialog"
 
 const ElementIcon = ({ elementType }: { elementType: MonsterElement }) => {
-  switch (elementType) {
-    case monsterElement.Enum.dark:
-      return <Icons.moon className="text-purple-700 dark:text-purple-400" />
-    case monsterElement.Enum.light:
-      return <Icons.sun className="text-yellow-700 dark:text-yellow-400" />
-    case monsterElement.Enum.water:
-      return <Icons.droplet className="text-sky-700 dark:text-sky-400" />
-    case monsterElement.Enum.wind:
-      return <Icons.wind className="text-green-700 dark:text-green-400" />
-    case monsterElement.Enum.fire:
-      return <Icons.flame className="text-red-700 dark:text-red-400" />
-  }
+  return <i className={clsx("monster-elements inline-block", elementType)} />
 }
 
 const MonsterTable = () => {

--- a/app/(auth)/src/hooks/useCommentDescription.ts
+++ b/app/(auth)/src/hooks/useCommentDescription.ts
@@ -1,0 +1,53 @@
+import { useSearchParams } from "next/navigation"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import axios from "axios"
+
+import { apiRoute } from "@/lib/api-route"
+import { getDynamicRoute } from "@/lib/utils"
+import { useToast } from "@/components/ui/use-toast"
+
+export default function useCommentDescription() {
+  const searchParams = useSearchParams()
+
+  const feedId = searchParams.get("feedId")
+
+  const { toast } = useToast()
+
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: updateCommentDescription, isLoading } = useMutation(
+    [apiRoute.Comment],
+    async ({
+      commentId,
+      description,
+    }: {
+      commentId: number
+      description: string
+    }) => {
+      if (!feedId) return
+
+      await axios.patch(
+        getDynamicRoute(apiRoute.CommentDescription, {
+          query: {
+            commentId,
+          },
+        }),
+        { description }
+      )
+    },
+    {
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries([apiRoute.Comment, feedId]),
+        ])
+
+        toast({
+          title: "공격덱 설명을 수정했습니다.",
+        })
+      },
+    }
+  )
+
+  return { updateCommentDescription, isLoading }
+}

--- a/app/(auth)/src/ui/card/comment-card.tsx
+++ b/app/(auth)/src/ui/card/comment-card.tsx
@@ -1,12 +1,21 @@
 "use client"
 
+import { useRef, useState } from "react"
+
 import { CommentItem } from "@/interface/comment"
 import { deckMonsterList } from "@/interface/monster"
 import { userRole } from "@/interface/user"
 import clsx from "clsx"
+import { useSession } from "next-auth/react"
 
 import { dateDistanceToNow } from "@/lib/date"
 import { Button } from "@/components/ui/button"
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card"
+import { Textarea } from "@/components/ui/textarea"
 import { Icons } from "@/components/common/icons"
 import MonsterImage from "@/components/common/monster-image"
 
@@ -14,81 +23,165 @@ import DeleteDialog from "../dialog/delete-dialog"
 
 interface CommentCardProps extends CommentItem {
   onDelete?: (id: number) => void
+  onDescriptionUpdate?: ({
+    commentId,
+    description,
+  }: {
+    commentId: number
+    description?: string
+  }) => void
 }
 
-const CommentCard = ({
+export default function CommentCard({
   id,
   author,
   createdAt,
   monsterList: attackMonsterList,
+  description,
   onDelete,
-}: CommentCardProps) => {
+  onDescriptionUpdate,
+}: CommentCardProps) {
+  const { data: session } = useSession()
+
+  const [isEdit, setIsEdit] = useState(false)
+
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+  const isAdmin =
+    author.role === userRole.Enum.ADMIN ||
+    session?.user.role === userRole.Enum.ADMIN
+
+  const isCreator = author.id === session?.user.id
+
+  const allowsEditing = isAdmin || isCreator
+
   const commentList = deckMonsterList.parse(attackMonsterList)
 
   return (
-    <div className="group relative flex h-max cursor-pointer justify-between gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
-      <div className="flex flex-col items-center gap-2 backdrop-blur-sm">
-        <div className="flex flex-col gap-1">
-          <span className="flex select-none flex-col">
-            <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
-              {author.role === userRole.Enum.ADMIN ? (
-                <Icons.crown className="mr-0.5" size={14} />
-              ) : (
-                <Icons.award size={14} />
-              )}
-              {author.guildName}
-            </em>
-            <em className="text-sm font-semibold not-italic text-foreground">
-              {author.nickname}
-            </em>
-          </span>
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <div className="group relative flex h-max cursor-pointer justify-between gap-6 overflow-hidden rounded-lg border p-4 shadow-sm transition-shadow duration-300 hover:shadow-md">
+          <div className="flex flex-col items-center gap-2 backdrop-blur-sm">
+            <div className="flex flex-col gap-1">
+              <span className="flex select-none flex-col">
+                <em className="flex items-center text-xs font-semibold not-italic text-gray-400">
+                  {isAdmin ? (
+                    <Icons.crown className="mr-0.5" size={14} />
+                  ) : (
+                    <Icons.award size={14} />
+                  )}
+                  {author.guildName}
+                </em>
+                <em className="text-sm font-semibold not-italic text-foreground">
+                  {author.nickname}
+                </em>
+              </span>
 
-          <span className="flex select-none gap-1 text-xs font-medium text-gray-400">
-            {dateDistanceToNow(createdAt)}
-          </span>
+              <span className="flex select-none gap-1 text-xs font-medium text-gray-400">
+                {dateDistanceToNow(createdAt)}
+              </span>
+            </div>
+          </div>
+
+          <div className="relative flex h-4/6 items-center justify-center gap-2">
+            {commentList.map((monsterInfo) => {
+              return (
+                <MonsterImage
+                  key={monsterInfo.id}
+                  className="z-0 cursor-pointer drop-shadow-lg"
+                  monsterInfo={monsterInfo}
+                />
+              )
+            })}
+          </div>
         </div>
-      </div>
+      </HoverCardTrigger>
 
-      <div className="relative z-50 flex h-4/6 items-center justify-center gap-2">
-        {commentList.map((monsterInfo) => {
-          return (
-            <MonsterImage
-              key={monsterInfo.id}
-              className="cursor-auto drop-shadow-lg"
-              monsterInfo={monsterInfo}
-            />
-          )
-        })}
-      </div>
+      <HoverCardContent
+        align="start"
+        alignOffset={4}
+        className="flex w-[300px] flex-col gap-2"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold not-italic text-foreground">
+            공격덱 설명
+          </span>
 
-      {onDelete && (
-        <div
-          className={clsx(
-            "absolute inset-0 z-50 flex items-center justify-center opacity-0 transition-all bg-foreground/30",
-            {
-              "group-hover:opacity-100": true,
-            }
-          )}
-        >
-          <DeleteDialog
-            title="공격덱을 삭제하시겠습니까?"
-            description="삭제한 공격덱은 복구가 불가능합니다."
-            onDelete={() => {
-              onDelete(id)
-            }}
-          >
-            <Button
-              className="hover:bg-transparent"
-              variant="ghost"
-              size="menu"
+          {allowsEditing && (
+            <DeleteDialog
+              title="공격덱을 삭제하시겠습니까?"
+              description="삭제한 공격덱은 복구가 불가능합니다."
+              onDelete={() => {
+                onDelete?.(id)
+              }}
             >
-              <i className="global-menu remove" />
-            </Button>
-          </DeleteDialog>
+              <Button variant="ghost" size="icon-sm">
+                <Icons.trash className="h-5 w-5 text-foreground opacity-70" />
+              </Button>
+            </DeleteDialog>
+          )}
         </div>
-      )}
-    </div>
+
+        <div className="flex flex-col gap-2">
+          {allowsEditing ? (
+            <>
+              {isEdit ? (
+                <>
+                  <Textarea
+                    ref={textAreaRef}
+                    className={clsx("text-sm text-gray-500 whitespace-pre", {
+                      "text-foreground": Boolean(description),
+                    })}
+                  >
+                    {description}
+                  </Textarea>
+
+                  <div className="flex gap-2">
+                    <Button
+                      className="flex-1"
+                      variant="outline"
+                      onClick={() => setIsEdit(false)}
+                    >
+                      취소
+                    </Button>
+
+                    <Button
+                      className="flex-1"
+                      variant="default"
+                      onClick={() =>
+                        onDescriptionUpdate?.({
+                          commentId: id,
+                          description: textAreaRef.current?.value,
+                        })
+                      }
+                    >
+                      저장
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="whitespace-pre text-sm text-gray-500">
+                    {description || ""}
+                  </p>
+
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() => setIsEdit(true)}
+                  >
+                    수정
+                  </Button>
+                </>
+              )}
+            </>
+          ) : (
+            <p className="whitespace-pre text-sm text-gray-500">
+              {description || "공격덱 설명이 없습니다."}
+            </p>
+          )}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
-
-export default CommentCard

--- a/app/(auth)/src/ui/card/comment-card.tsx
+++ b/app/(auth)/src/ui/card/comment-card.tsx
@@ -108,17 +108,32 @@ export default function CommentCard({
           </span>
 
           {allowsEditing && (
-            <DeleteDialog
-              title="공격덱을 삭제하시겠습니까?"
-              description="삭제한 공격덱은 복구가 불가능합니다."
-              onDelete={() => {
-                onDelete?.(id)
-              }}
-            >
-              <Button variant="ghost" size="icon-sm">
-                <Icons.trash className="h-5 w-5 text-foreground opacity-70" />
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title="수정"
+                onClick={() => setIsEdit(true)}
+              >
+                <Icons.fileEdit className="h-5 w-5 text-foreground opacity-70" />
+
+                <span className="sr-only">수정</span>
               </Button>
-            </DeleteDialog>
+
+              <DeleteDialog
+                title="공격덱을 삭제하시겠습니까?"
+                description="삭제한 공격덱은 복구가 불가능합니다."
+                onDelete={() => {
+                  onDelete?.(id)
+                }}
+              >
+                <Button variant="ghost" size="icon-sm" title="삭제">
+                  <Icons.trash className="h-5 w-5 text-foreground opacity-70" />
+
+                  <span className="sr-only">삭제</span>
+                </Button>
+              </DeleteDialog>
+            </div>
           )}
         </div>
 
@@ -160,19 +175,9 @@ export default function CommentCard({
                   </div>
                 </>
               ) : (
-                <>
-                  <p className="whitespace-pre text-sm text-gray-500">
-                    {description || ""}
-                  </p>
-
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={() => setIsEdit(true)}
-                  >
-                    수정
-                  </Button>
-                </>
+                <p className="whitespace-pre text-sm text-gray-500">
+                  {description || "공격덱 설명을 작성해주세요."}
+                </p>
               )}
             </>
           ) : (

--- a/app/(auth)/src/ui/card/feed-card.tsx
+++ b/app/(auth)/src/ui/card/feed-card.tsx
@@ -19,7 +19,7 @@ interface FeedCardProps extends FeedItem {
   onDelete?: (id: number) => void
 }
 
-const FeedCard = ({
+export default function FeedCard({
   id,
   author,
   viewCount,
@@ -27,7 +27,7 @@ const FeedCard = ({
   monsterList,
   comments,
   onDelete,
-}: FeedCardProps) => {
+}: FeedCardProps) {
   const defenseMonsterList = monsterList as DeckMonsterList
   const attackMonsterList = comments as Comment[]
 
@@ -125,5 +125,3 @@ const FeedCard = ({
     </div>
   )
 }
-
-export default FeedCard

--- a/app/(auth)/src/ui/dialog/comment-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/comment-dialog.tsx
@@ -14,12 +14,14 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 import {
   Form,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/components/ui/use-toast"
 import FullPageLoading from "@/components/common/loading/full-page"
 import MonsterImage from "@/components/common/monster-image"
@@ -65,6 +67,7 @@ export default function CommentDialog({ children }: CommentDialogProps) {
     resolver: zodResolver(attackMonster),
     defaultValues: {
       attackMonsterList: [],
+      description: "",
     },
   })
 
@@ -84,6 +87,7 @@ export default function CommentDialog({ children }: CommentDialogProps) {
 
   const handleSubmit = (values: AttackMonster) => {
     createComment(values)
+
     handleReset()
   }
 
@@ -100,7 +104,7 @@ export default function CommentDialog({ children }: CommentDialogProps) {
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
 
-      <DialogContent className="max-w-xs max-md:max-w-[calc(100%-48px)]">
+      <DialogContent className="max-w-md max-md:max-w-[calc(100%-48px)]">
         <Form {...form}>
           <form
             className="relative flex h-full max-h-full flex-col gap-4"
@@ -195,6 +199,23 @@ export default function CommentDialog({ children }: CommentDialogProps) {
                       )
                     })}
                   </div>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Separator className="max-md:hidden" />
+
+            <FormField
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>설명</FormLabel>
+
+                  <FormDescription>공격덱의 설명을 남겨주세요.</FormDescription>
+
+                  <Textarea placeholder="설명을 입력해주세요." {...field} />
 
                   <FormMessage />
                 </FormItem>

--- a/app/(auth)/src/ui/dialog/delete-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/delete-dialog.tsx
@@ -20,12 +20,12 @@ interface DeleteDialogProps {
   onDelete: () => void
 }
 
-const DeleteDialog = ({
+export default function DeleteDialog({
   children,
   title,
   description,
   onDelete,
-}: DeleteDialogProps) => {
+}: DeleteDialogProps) {
   return (
     <AlertDialog>
       <AlertDialogTrigger
@@ -66,5 +66,3 @@ const DeleteDialog = ({
     </AlertDialog>
   )
 }
-
-export default DeleteDialog

--- a/app/(auth)/src/ui/dialog/monster-manage-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/monster-manage-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -32,6 +33,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { Icons } from "@/components/common/icons"
 import Tag from "@/components/common/tag"
 
 const elementTypeLabel = {
@@ -53,12 +61,12 @@ export interface MonsterManageDialogProps {
   initValue?: MonsterInfo
 }
 
-const MonsterManageDialog = ({
+export default function MonsterManageDialog({
   children,
   title,
   onSubmit,
   initValue,
-}: MonsterManageDialogProps) => {
+}: MonsterManageDialogProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const form = useForm<MonsterInfo>({
@@ -188,9 +196,24 @@ const MonsterManageDialog = ({
                 <FormItem>
                   <FormLabel>키워드</FormLabel>
 
+                  <FormDescription className="flex items-center gap-1">
+                    키워드를 입력하고 스페이스바를 눌러주세요.
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Icons.info size={16} />
+                        </TooltipTrigger>
+
+                        <TooltipContent>
+                          추가한 키워드를 클릭하면 삭제할 수 있습니다.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </FormDescription>
+
                   <FormControl>
                     <Input
-                      placeholder="키워드를 입력하고 스페이스바를 눌러주세요."
+                      placeholder="키워드를 입력해주세요."
                       onKeyUp={(e) => {
                         const keyword = getKeyword(e)
 
@@ -249,5 +272,3 @@ const MonsterManageDialog = ({
     </Dialog>
   )
 }
-
-export default MonsterManageDialog

--- a/app/(auth)/src/ui/sheet/comment-sheet.tsx
+++ b/app/(auth)/src/ui/sheet/comment-sheet.tsx
@@ -27,6 +27,7 @@ import Loading from "@/components/common/loading"
 import MonsterImage from "@/components/common/monster-image"
 
 import useCommentDelete from "../../hooks/useCommentDelete"
+import useCommentDescription from "../../hooks/useCommentDescription"
 import useCommentList from "../../hooks/useCommentList"
 import CommentCard from "../card/comment-card"
 import CommentDialog from "../dialog/comment-dialog"
@@ -52,9 +53,17 @@ export default function CommentSheet() {
   const { deleteComment, isLoading: isDeleteCommentLoading } =
     useCommentDelete()
 
+  const {
+    updateCommentDescription,
+    isLoading: isUpdateCommentDescriptionLoading,
+  } = useCommentDescription()
+
   const isPresent = useIsPresent()
 
-  const isLoading = isCommentListLoading || isDeleteCommentLoading
+  const isLoading =
+    isCommentListLoading ||
+    isDeleteCommentLoading ||
+    isUpdateCommentDescriptionLoading
 
   const sessionUserId = session?.user.id
 
@@ -78,6 +87,18 @@ export default function CommentSheet() {
     if (!feedId) throw Error(apiErrorMessage.BadRequest)
 
     deleteComment(commentId)
+  }
+
+  const handleCommentDescriptionUpdate = ({
+    commentId,
+    description,
+  }: {
+    commentId: number
+    description?: string
+  }) => {
+    if (!description) return
+
+    updateCommentDescription({ commentId, description })
   }
 
   return (
@@ -174,6 +195,7 @@ export default function CommentSheet() {
                                 ? (id) => handleCommentDelete(id)
                                 : undefined
                             }
+                            onDescriptionUpdate={handleCommentDescriptionUpdate}
                           />
                         </motion.li>
                       )

--- a/app/api/comment/description/route.ts
+++ b/app/api/comment/description/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import prisma from "@/lib/prisma"
+
+import { createApiErrorResponse } from "../../action"
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const { description }: { description: string } = await request.json()
+
+    const { searchParams } = new URL(request.url)
+
+    const commentId = searchParams.get("commentId")
+
+    if (!commentId) return createApiErrorResponse("BadRequest")
+
+    await prisma.comment.update({
+      where: {
+        id: commentId,
+      },
+      data: {
+        description,
+      },
+    })
+
+    return NextResponse.json({ status: "ok" })
+  } catch (error) {
+    return createApiErrorResponse("ServerError")
+  }
+}

--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -54,8 +54,11 @@ export async function POST(request: NextRequest) {
   try {
     const payload = await request.json()
 
-    const { feedId, attackMonsterList: monsterList } =
-      attackMonster.parse(payload)
+    const {
+      feedId,
+      attackMonsterList: monsterList,
+      description,
+    } = attackMonster.parse(payload)
 
     const session = await getServerSession(authOptions)
 
@@ -103,6 +106,7 @@ export async function POST(request: NextRequest) {
     await prisma.comment.create({
       data: {
         monsterList,
+        description,
         authorId: session.user.id,
         feedId: Number(feedId),
       },
@@ -110,6 +114,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ status: "ok" })
   } catch (error) {
+    console.log(error)
     if (error instanceof z.ZodError) {
       return createApiErrorResponse("BadRequest")
     }

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardContent, HoverCardTrigger }

--- a/interface/comment.ts
+++ b/interface/comment.ts
@@ -6,6 +6,7 @@ import { deckMonsterList } from "./monster"
 const attackMonster = z.object({
   feedId: z.string().optional(),
   attackMonsterList: deckMonsterList,
+  description: z.string().optional(),
 })
 
 type AttackMonster = z.infer<typeof attackMonster>

--- a/lib/api-route.ts
+++ b/lib/api-route.ts
@@ -4,6 +4,7 @@ const apiRoute = {
   User: "/api/user",
   Feed: "/api/feed",
   Comment: "/api/comment",
+  CommentDescription: "/api/comment/description",
   Notification: "/api/notification",
   Sheet: "/api/sheet",
   Me: "/api/me",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",
+    "@radix-ui/react-hover-card": "^1.0.7",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-popover": "^1.0.6",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,8 @@ model Comment {
   feed   Feed @relation(fields: [feedId], references: [id], onDelete: Cascade)
   feedId Int
 
+  description String? @default("")
+
   @@index([feedId])
   @@index([authorId])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,6 +921,22 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-callback-ref" "1.0.1"
 
+"@radix-ui/react-hover-card@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-hover-card/-/react-hover-card-1.0.7.tgz#684bca2504432566357e7157e087051aa3577948"
+  integrity sha512-OcUN2FU0YpmajD/qkph3XzMcK/NmSk9hGWnjV68p6QiZMgILugusgQwnLSDs3oFSJYGKf3Y49zgFedhGh04k9A==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-id@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.0.tgz#8d43224910741870a45a8c9d092f25887bb6d11e"
@@ -1017,6 +1033,23 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.2.tgz#4c0b96fcd188dc1f334e02dba2d538973ad842e9"
   integrity sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@floating-ui/react-dom" "^2.0.0"


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- fix(comment): comment 내부 description 기능 추가
- 어드민 > 몬스터 수정 페이지
  - 속성 이미지를 수정했습니다.
  - 저장된 키워드를 삭제하는 방법을 툴팁으로 표기하도록 추가했습니다. 

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 공격덱 추가시 운용방법 등등 추가설명이 필요한 내용을 저장하는 필드를 추가했습니다
![image](https://github.com/cyclops-operation/switter/assets/85790271/b14e08ae-1ceb-4f01-bbf6-19d1e7e07a30)

- 어드민, 공격덱을 추가한 유저만 공격덱을 삭제하거나 내용을 수정 할 수 있습니다. ( 임시 UI로 변경 예정 )
![스크린샷 2023-10-22 오후 6 52 55](https://github.com/cyclops-operation/switter/assets/85790271/f236628a-3a3c-42d4-8b2a-ce5a87b06d89)
![스크린샷 2023-10-22 오후 6 53 57](https://github.com/cyclops-operation/switter/assets/85790271/3f57886a-c13a-4c0f-9fdb-bace63b1d9d3)

- 일반 유저는 저장된 내용만 볼 수 있습니다. ( 임시 UI로 변경될 예정 )
![스크린샷 2023-10-22 오후 6 53 45](https://github.com/cyclops-operation/switter/assets/85790271/ad8d40fa-960b-4c08-83c4-fb31bf71e079)

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 빠르게 반영하기 위해 [HoverCard](https://ui.shadcn.com/docs/components/hover-card) 컴포넌트를 추가했습니다.
- 몬스터 정보를 수정하는 부분의 속성, 툴팁이 추가되었습니다.
> 속성 이미지 변경

![image](https://github.com/cyclops-operation/switter/assets/85790271/2eb83f52-c5af-415b-b226-48b69fa52f2d)

> 키워드 툴팁 추가

![image](https://github.com/cyclops-operation/switter/assets/85790271/088efffb-154e-4f8f-9b4a-0df8214c4e25)



## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
