### PR TITLE
fix(feed): 피드 생성시 keyword 값 옵셔널로 변경 (#90)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,6 @@
     "editor.defaultFormatter": "Prisma.prisma"
   },
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   }
 }

--- a/app/(auth)/src/ui/dialog/feed-dialog.tsx
+++ b/app/(auth)/src/ui/dialog/feed-dialog.tsx
@@ -14,7 +14,6 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -105,10 +104,6 @@ export default function FeedDialog({ children }: FeedDialogProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>키워드</FormLabel>
-
-                  <FormDescription>
-                    키워드를 저장해야 검색이 가능합니다.
-                  </FormDescription>
 
                   <FormControl>
                     <Input

--- a/interface/feed.ts
+++ b/interface/feed.ts
@@ -8,8 +8,8 @@ import { deckMonsterList } from "./monster"
 const defenseMonster = z.object({
   keyword: z
     .string()
-    .min(3, { message: formErrorMessage.keyword.minLength })
-    .max(3, { message: formErrorMessage.keyword.maxLength }),
+    .max(3, { message: formErrorMessage.keyword.maxLength })
+    .optional(),
   defencseMonsterList: deckMonsterList,
 })
 


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- 피드 생성시 keyword 입력값을 옵셔널로 변경

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 유저 요청사항으로 피드 생성시 keyword 를 입력하지 않아도 생성되도록 추가했습니다

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
